### PR TITLE
Fixed data preparation

### DIFF
--- a/data.py
+++ b/data.py
@@ -36,7 +36,7 @@ def prepare_data(sample, reduce_ratio=1.0, fixed_size=None):
     gt = gt.replace("\t", " <t> ")
     gt = gt.replace("\n", " <b> ")
 
-    sample["transcription"] = gt.split(" ")
+    sample["transcription"] = ["<bos>"] + gt.split(" ") + ["<eos>"]
     sample["image"] = pil_image.fromarray(img)
 
     return sample


### PR DESCRIPTION
Fixed error in prepare_data function. <bos> and <eos> tokens were not being added to the transcription.

Solution: adding ```["<bos>"] + gt.split(" ") + ["<eos>"]``` to the line that updates the trasncription field of each sample in the dataset.