### PR TITLE
Bugfix and slight optimization of calculation of CER/SER/LER

### DIFF
--- a/config/Camera_GrandStaff/c_grandstaff.json
+++ b/config/Camera_GrandStaff/c_grandstaff.json
@@ -6,5 +6,10 @@
       "img_format": "_distorted.jpg",
       "num_workers": 20,
       "reduce_ratio": 0.85
-    }
+    },
+	"checkpoint": {
+		"dirpath": "weights/CameraGrandStaff",
+		"filename": "CameraGrandStaff",
+		"monitor": "val_SER"
+	}
 }

--- a/config/GrandStaff/grandstaff.json
+++ b/config/GrandStaff/grandstaff.json
@@ -6,5 +6,10 @@
       "img_format": ".jpg",
       "num_workers": 20,
       "reduce_ratio": 1.0
-    }
+    },
+	"checkpoint": {
+		"dirpath": "weights/GrandStaff",
+		"filename": "GrandStaff",
+		"monitor": "val_SER"
+	}
 }

--- a/config/StringQuartets/quartets.json
+++ b/config/StringQuartets/quartets.json
@@ -6,5 +6,10 @@
       "img_format": "_distorted.png",
       "num_workers": 20,
       "reduce_ratio": 1.0
-    }
+    },
+	"checkpoint": {
+		"dirpath": "weights/StringQuartets",
+		"filename": "StringQuartets",
+		"monitor": "val_SER"
+	}
 }

--- a/data.py
+++ b/data.py
@@ -5,16 +5,13 @@ import cv2
 import torch
 import numpy as np
 import cv2
-import wandb
 
 import datasets
 from ExperimentConfig import ExperimentConfig
 from data_augmentation.data_augmentation import augment, convert_img_to_tensor
 from utils import check_and_retrieveVocabulary, parse_kern
-from rich import progress
 from lightning import LightningDataModule
 from torch.utils.data import Dataset
-from torchvision import transforms
 from SynthGenerator import VerovioGenerator
 
 # For single-system datasets
@@ -104,14 +101,14 @@ def batch_preparation_img2seq(data):
 
     max_length_seq = max([len(w) for w in gt])
 
-    decoder_input = torch.zeros(size=[len(dec_in),max_length_seq])
-    y = torch.zeros(size=[len(gt),max_length_seq])
+    decoder_input = torch.zeros(size=[len(dec_in),max_length_seq-1]) # <eos> will be removed
+    y = torch.zeros(size=[len(gt),max_length_seq-1]) # <bos> will be removed
 
     for i, seq in enumerate(dec_in):
-        decoder_input[i, 0:len(seq)-1] = torch.from_numpy(np.asarray([char for char in seq[:-1]]))
+        decoder_input[i] = torch.from_numpy(np.asarray([char for char in seq[:-1]])) # all tokens but <eos>
 
     for i, seq in enumerate(gt):
-        y[i, 0:len(seq)-1] = torch.from_numpy(np.asarray([char for char in seq[1:]]))
+        y[i] = torch.from_numpy(np.asarray([char for char in seq[1:]])) # all tokens but <bos>
 
     return X_train, decoder_input.long(), y.long()
 

--- a/data.py
+++ b/data.py
@@ -44,7 +44,7 @@ def prepare_data(sample, reduce_ratio=1.0, fixed_size=None):
 
 def load_set(dataset, split="train", reduce_ratio=1.0, fixed_size=None):
     ds = datasets.load_dataset(dataset, split=split, trust_remote_code=False)
-    ds = ds.map(prepare_data, fn_kwargs={"reduce_ratio": reduce_ratio, "fixed_size": fixed_size}, num_proc=8)
+    ds = ds.map(prepare_data, fn_kwargs={"reduce_ratio": reduce_ratio, "fixed_size": fixed_size}, num_proc=4, writer_batch_size=500)
 
     return ds
 
@@ -555,8 +555,8 @@ class SyntheticCLGrandStaffDataset(LightningDataModule):
         return max(Tl, vl, tl, 4353)
 
     def train_dataloader(self):
-        # return torch.utils.data.DataLoader(self.train_set, batch_size=self.batch_size, num_workers=self.num_workers, shuffle=True, collate_fn=batch_preparation_img2seq)
-        return torch.utils.data.DataLoader(self.train_set, batch_size=self.batch_size, num_workers=0, shuffle=True, collate_fn=batch_preparation_img2seq)
+        return torch.utils.data.DataLoader(self.train_set, batch_size=self.batch_size, num_workers=self.num_workers, shuffle=True, collate_fn=batch_preparation_img2seq)
+        # return torch.utils.data.DataLoader(self.train_set, batch_size=self.batch_size, num_workers=0, shuffle=True, collate_fn=batch_preparation_img2seq)
 
     def val_dataloader(self):
         return torch.utils.data.DataLoader(self.val_set, batch_size=self.batch_size, num_workers=self.num_workers, collate_fn=batch_preparation_img2seq)

--- a/eval_functions.py
+++ b/eval_functions.py
@@ -1,24 +1,25 @@
 from utils import levenshtein
 
-def parse_krn_content(krn, ler_parsing=False, cer_parsing=False):
+def parse_krn_content(krn: str, ler_parsing=False, cer_parsing=False):
     if cer_parsing:
-        krn = krn.replace("\n", " <b> ")
-        krn = krn.replace("\t", " <t> ")
-        tokens = krn.split(" ")
-        characters = []
-        for token in tokens:
-            if token in ['<b>', '<t>']:
-                characters.append(token)
-            else:
-                for char in token:
-                    characters.append(char)
-        return characters
+        # krn = krn.replace("\n", " <b> ")
+        # krn = krn.replace("\t", " <t> ")
+        # tokens = krn.split(" ")
+        # characters = []
+        # for token in tokens:
+            # if token in ['<b>', '<t>']:
+                # characters.append(token)
+            # else:
+                # for char in token:
+                    # characters.append(char)
+        # return characters
+        return list(krn)
     elif ler_parsing:
         krn_lines = krn.split("\n")
-        for i, line in enumerate(krn_lines):
-            line = line.replace("\n", " <b> ")
-            line = line.replace("\t", " <t> ")
-            krn_lines[i] = line
+        # for i, line in enumerate(krn_lines):
+            # line = line.replace("\n", " <b> ")
+            # line = line.replace("\t", " <t> ")
+            # krn_lines[i] = line
         return krn_lines
     else:
         krn = krn.replace("\n", " <b> ")
@@ -54,18 +55,7 @@ def compute_poliphony_metrics(hyp_array, gt_array):
 
         hyp_cer.append(parse_krn_content(h_string, ler_parsing=False, cer_parsing=True))
         gt_cer.append(parse_krn_content(gt_string, ler_parsing=False, cer_parsing=True))
-    
-    acc_ed_dist = 0
-    acc_len = 0
 
-    cer = 0
-    ser = 0
-    ler = 0
-
-    for (h, g) in zip(hyp_cer, gt_cer):
-        acc_ed_dist += levenshtein(h, g)
-        acc_len += len(g)
-    
     cer = compute_metric(hyp_cer, gt_cer)
     ser = compute_metric(hyp_ser, gt_ser)
     ler = compute_metric(hyp_ler, gt_ler)

--- a/smt_model/modeling_smt.py
+++ b/smt_model/modeling_smt.py
@@ -393,7 +393,7 @@ class SMTModelForCausalLM(PreTrainedModel):
         output = self.forward_decoder(x, decoder_input)
 
         if labels is not None:
-            output.loss = self.loss(output.logits.permute(0,2,1).contiguous(), labels[:, :-1])
+            output.loss = self.loss(output.logits.permute(0,2,1).contiguous(), labels)
 
         return output
 

--- a/smt_trainer.py
+++ b/smt_trainer.py
@@ -48,7 +48,7 @@ class SMT_Trainer(L.LightningModule):
 
     def training_step(self, batch):
         x, di, y = batch
-        outputs = self.model(encoder_input=x, decoder_input=di[:, :-1], labels=y)
+        outputs = self.model(encoder_input=x, decoder_input=di, labels=y)
         loss = outputs.loss
 
         stage = self.stage_calculator(self.global_step)
@@ -68,7 +68,7 @@ class SMT_Trainer(L.LightningModule):
         dec = dec.replace("<b>", "\n")
         dec = dec.replace("<s>", " ")
 
-        gt = "".join([self.model.i2w[token.item()] for token in y.squeeze(0)[:-1]])
+        gt = "".join([self.model.i2w[token.item()] for token in y.squeeze(0)[:-1]]) # Remove <eos>
         gt = gt.replace("<t>", "\t")
         gt = gt.replace("<b>", "\n")
         gt = gt.replace("<s>", " ")


### PR DESCRIPTION
This pull requests contains changes that fix #16 by solving its root cause, found in the data loading (collate_fn) process.

Furthermore, a redundant calculation of the CER is removed. The simple parsing applied to the prediction and ground truth for CER and LER have been simplified, the parsing applied for the CER could be further simplified as the levenshtein function only requires its inputs to implement the `__getitem__` method, and string does implement it.

Also added checkpointer configs to the Camera_Grandstaff, StringQuartets and system-level GrandStaff.