### PR TITLE
fix: downgrade the vervio dependency to decrease a chance of seg faults

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,5 +17,6 @@ dependencies = [
     "torchinfo>=1.8.0",
     "torchvision>=0.21.0",
     "transformers>=4.49.0",
+    "verovio==5.0.0",
     "wandb>=0.19.7",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ transformers
 visualizer
 datasets
 
-verovio
+verovio==5.0.0
 wand
 cairosvg
 names


### PR DESCRIPTION
Downgrade the vervio dependency to decrease a chance of seg faults.

[relevant issue](https://github.com/antoniorv6/SMT/issues/38)
[relevant comment
](https://github.com/antoniorv6/SMT/issues/38#issuecomment-4116473342)